### PR TITLE
Add HairU logo asset and showcase it in layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -50,10 +50,15 @@ header {
 }
 
 .logo {
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  font-size: 1.25rem;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  max-width: 9rem;
+}
+
+.logo img {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .nav-links {
@@ -100,6 +105,24 @@ header {
   max-width: var(--max-width);
   margin: 0 auto;
   padding: 5rem 1.5rem 4rem;
+}
+
+.hero-logo {
+  width: min(260px, 60%);
+  height: auto;
+  margin-bottom: 1.75rem;
+  filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.35));
+}
+
+@media (max-width: 720px) {
+  .logo {
+    max-width: 7.5rem;
+  }
+
+  .hero-logo {
+    width: min(220px, 70%);
+    margin-bottom: 1.5rem;
+  }
 }
 
 .hero-content h1 {

--- a/assets/images/hairu-logo.svg
+++ b/assets/images/hairu-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" role="img" aria-labelledby="title desc">
+  <title id="title">HairU Hair Salon logo</title>
+  <desc id="desc">Stylized silver flame over the word HairU Hair Salon on a charcoal background.</desc>
+  <defs>
+    <linearGradient id="flameGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#d5d5d5" />
+      <stop offset="100%" stop-color="#a7a7a7" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" fill="#090909" rx="40" />
+  <g transform="translate(300 180)">
+    <path d="M0 -120 C 30 -70 20 -20 5 30 C -10 80 -5 120 30 140 C -5 140 -45 110 -40 60 C -35 10 15 -40 0 -120 Z" fill="url(#flameGradient)" />
+    <path d="M-60 -100 C -30 -60 -40 -10 -55 40 C -70 90 -65 130 -30 150 C -65 150 -105 120 -100 70 C -95 20 -45 -30 -60 -100 Z" fill="url(#flameGradient)" opacity="0.85" />
+    <path d="M60 -100 C 90 -60 80 -10 65 40 C 50 90 55 130 90 150 C 55 150 15 120 20 70 C 25 20 75 -30 60 -100 Z" fill="url(#flameGradient)" opacity="0.85" />
+  </g>
+  <text x="50%" y="360" text-anchor="middle" font-size="96" fill="#c9c9c9" font-family="'Cinzel', 'Times New Roman', serif" letter-spacing="8">HAIRU</text>
+  <text x="50%" y="430" text-anchor="middle" font-size="42" fill="#b0b0b0" font-family="'Cinzel', 'Times New Roman', serif" letter-spacing="6">HAIR SALON</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,9 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary navigation">
-        <a class="logo" href="#home">HairU Salon</a>
+        <a class="logo" href="#home" aria-label="HairU Salon home">
+          <img src="assets/images/hairu-logo.svg" alt="HairU Hair Salon logo" />
+        </a>
         <button class="mobile-toggle" aria-label="Toggle navigation" aria-expanded="false">
           &#9776;
         </button>
@@ -36,6 +38,12 @@
     <main>
       <section id="home" class="hero">
         <div class="hero-content">
+          <img
+            class="hero-logo"
+            src="assets/images/hairu-logo.svg"
+            alt=""
+            aria-hidden="true"
+          />
           <p class="eyebrow">A modern sanctuary for hair artistry</p>
           <h1>Transform your look with luminous color & precision cuts.</h1>
           <p>


### PR DESCRIPTION
## Summary
- add a scalable HairU logo asset with the brand flame and wordmark
- replace the text logo in the navigation with the new artwork and surface it in the hero
- adjust layout styling so the logo renders cleanly on desktop and mobile widths

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e8e2c40ce0832ca5e78f795eaa4e40