### PR TITLE
Support client gallery without bundled photos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary

--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ This repository contains the source code for the **HairU Salon** marketing websi
 - Adjust colors, typography, and spacing inside `assets/css/styles.css`.
 - Replace contact details and the Formspree endpoint with your own information.
 
+## Client Imagery Assets
+
+The homepage is styled to showcase real client transformations using background images. To keep this repository lightweight, the
+`assets/images/clients/` folder is intentionally committed empty (aside from a `.gitkeep` placeholder). Add your own salon
+photography to that folder and the hero banner plus gallery cards will automatically pick up the files because each block
+references descriptive filenames via CSS custom properties.
+
+### Working with images in Git
+
+- Place optimized PNG or JPG photos inside `assets/images/clients/` so the HTML and CSS references keep working.
+- When you are ready to publish, commit the updated images in the same branch as your markup and style changes so the live site renders the photography. (During code review you can keep the directory empty if you prefer not to share client imagery publicly.)
+- No special setup (like Git LFS) is required; Git can version-track PNGs directly. Just make sure your editor stages the files before committing.
+
+### Troubleshooting binary file errors when opening a PR
+
+If your Git client reports an error about binary files while you are trying to raise a pull request, follow these steps:
+
+1. **Verify the files are staged.** Run `git status` and confirm the PNGs under `assets/images/clients/` appear under "Changes to be committed". If they do not, add them explicitly with `git add assets/images/clients/*.png`.
+2. **Ensure Git treats the assets as binary.** This repository includes a `.gitattributes` file that marks common image formats as binary. Pull the latest changes or copy the file into your branch before committing.
+3. **Recreate the commit if necessary.** Should the error persist, run `git reset HEAD~` to undo the problematic commit, stage the images again, and commit with a fresh message such as `git commit -m "Add client imagery"`.
+4. **Push and open the PR.** Once the commit succeeds locally, push your branch and open the pull request. Because the images are already tracked in Git, no extra upload step in the PR UI is required.
+
+Following the checklist above typically resolves binary-asset warnings that occur when the images were never staged or when a branch was missing the `.gitattributes` metadata.
+
 ## License
 
 This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -190,21 +190,15 @@ header {
   border-radius: 2rem;
   overflow: hidden;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
-}
-
-.hero-image::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(214, 163, 84, 0.4), transparent 60%);
-  z-index: 1;
-}
-
-.hero-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: grayscale(20%) contrast(1.05);
+  background-color: #161618;
+  background-image: linear-gradient(135deg, rgba(214, 163, 84, 0.38), rgba(17, 17, 20, 0.65)),
+    var(
+      --hero-image,
+      radial-gradient(circle at 25% 25%, rgba(214, 163, 84, 0.35), rgba(15, 15, 16, 0.9))
+    );
+  background-size: cover, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
 }
 
 section {
@@ -259,6 +253,63 @@ section {
 .service-card p {
   margin: 0;
   color: var(--text-muted);
+}
+
+.client-gallery {
+  background: linear-gradient(180deg, rgba(214, 163, 84, 0.08), rgba(15, 15, 16, 0.9));
+}
+
+.client-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.client-card {
+  background: rgba(17, 17, 20, 0.85);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(214, 163, 84, 0.14);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+  display: flex;
+  flex-direction: column;
+}
+
+.client-card:hover,
+.client-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(214, 163, 84, 0.45);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.client-photo {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  background-color: rgba(17, 17, 20, 0.95);
+  background-image: linear-gradient(180deg, rgba(17, 17, 20, 0.1), rgba(17, 17, 20, 0.75)),
+    var(
+      --client-image,
+      radial-gradient(circle at 22% 20%, rgba(214, 163, 84, 0.35), rgba(15, 15, 16, 0.85))
+    );
+  background-size: cover, cover;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+  border-bottom: 1px solid rgba(214, 163, 84, 0.18);
+  filter: saturate(1.05) contrast(1.05);
+}
+
+.client-card figcaption {
+  padding: 1.5rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.client-card figcaption::before {
+  content: '\2726';
+  color: var(--accent-color);
+  margin-right: 0.5rem;
 }
 
 .testimonial-list {
@@ -438,6 +489,12 @@ footer a {
 
   .mobile-toggle {
     display: block;
+  }
+}
+
+@media (max-width: 540px) {
+  .client-card img {
+    height: 200px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <div class="nav-links" role="menu">
           <a href="#home" role="menuitem">Home</a>
           <a href="#services" role="menuitem">Services</a>
+          <a href="#clients" role="menuitem">Client Results</a>
           <a href="#testimonials" role="menuitem">Testimonials</a>
           <a href="#contact" role="menuitem">Contact</a>
           <a href="#directions" role="menuitem">Directions</a>
@@ -56,9 +57,12 @@
             <a class="btn btn-secondary" href="#contact">Book a Consultation</a>
           </div>
         </div>
-        <div class="hero-image" aria-hidden="true">
-          <img src="https://images.unsplash.com/photo-1507676184212-d03ab07a01bf?auto=format&fit=crop&w=900&q=80" alt="Stylist cutting hair in a modern salon" />
-        </div>
+        <div
+          class="hero-image"
+          role="img"
+          aria-label="Honey balayage with voluminous waves styled in the salon"
+          style="--hero-image: url('assets/images/clients/balayage-honey-waves.png')"
+        ></div>
       </section>
 
       <section id="services" aria-labelledby="services-title">
@@ -97,6 +101,54 @@
               celebrations.
             </p>
           </article>
+        </div>
+      </section>
+
+      <section id="clients" class="client-gallery" aria-labelledby="clients-title">
+        <div class="section-header">
+          <h2 id="clients-title">Client Transformations</h2>
+          <p>
+            Explore recent looks crafted by the HairU artists&mdash;dimensional color, precise cuts, and restorative care that
+            celebrate every guest.
+          </p>
+        </div>
+        <div class="client-gallery-grid" role="list">
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Balayage highlights blending honey and caramel tones on long waves"
+              style="--client-image: url('assets/images/clients/balayage-honey-waves.png')"
+            ></div>
+            <figcaption>Honey balayage with luminous waves and seamless blending.</figcaption>
+          </figure>
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Precision chin-length bob with mirror-like shine"
+              style="--client-image: url('assets/images/clients/precision-bob-shine.png')"
+            ></div>
+            <figcaption>Glass-finish precision bob tailored for effortless movement.</figcaption>
+          </figure>
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Vivid copper color with soft face-framing highlights"
+              style="--client-image: url('assets/images/clients/vivid-copper-lights.png')"
+            ></div>
+            <figcaption>Vivid copper color melt with soft, face-framing brightness.</figcaption>
+          </figure>
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Defined natural curls after hydration treatment"
+              style="--client-image: url('assets/images/clients/natural-curl-revive.png')"
+            ></div>
+            <figcaption>Hydrating curl revival that boosts definition and bounce.</figcaption>
+          </figure>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- refactor the hero and client gallery to use background images driven by CSS custom properties so the layout still renders when no photos are committed
- refresh the related styling with gradient fallbacks that keep the dark-luxe presentation even when placeholders are shown
- document that `assets/images/clients/` is intentionally empty (aside from `.gitkeep`) and remove the sample PNGs so downstream teams can add their own imagery

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e94e3834c0832caac56bbc278a077f