### PR TITLE
Integrate new client photography assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
         <div
           class="hero-image"
           role="img"
-          aria-label="Honey balayage with voluminous waves styled in the salon"
-          style="--hero-image: url('assets/images/clients/balayage-honey-waves.png')"
+          aria-label="Salon client with luminous waves and dimensional color"
+          style="--hero-image: url('/assets/images/clients/img-11.jpg')"
         ></div>
       </section>
 
@@ -117,37 +117,55 @@
             <div
               class="client-photo"
               role="img"
-              aria-label="Balayage highlights blending honey and caramel tones on long waves"
-              style="--client-image: url('assets/images/clients/balayage-honey-waves.png')"
+              aria-label="Client portrait showing soft waves with subtle highlights"
+              style="--client-image: url('/assets/images/clients/img-10.jpg')"
             ></div>
-            <figcaption>Honey balayage with luminous waves and seamless blending.</figcaption>
+            <figcaption>Polished finish with touchable waves and dimensional shine.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
             <div
               class="client-photo"
               role="img"
-              aria-label="Precision chin-length bob with mirror-like shine"
-              style="--client-image: url('assets/images/clients/precision-bob-shine.png')"
+              aria-label="Client portrait featuring a sleek, shoulder-length cut"
+              style="--client-image: url('/assets/images/clients/img-8.jpg')"
             ></div>
-            <figcaption>Glass-finish precision bob tailored for effortless movement.</figcaption>
+            <figcaption>Sleek silhouette paired with a smooth, reflective finish.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
             <div
               class="client-photo"
               role="img"
-              aria-label="Vivid copper color with soft face-framing highlights"
-              style="--client-image: url('assets/images/clients/vivid-copper-lights.png')"
+              aria-label="Client portrait highlighting a rich brunette color service"
+              style="--client-image: url('/assets/images/clients/img-6.jpg')"
             ></div>
-            <figcaption>Vivid copper color melt with soft, face-framing brightness.</figcaption>
+            <figcaption>Rich color depth enhanced with healthy, light-catching gloss.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
             <div
               class="client-photo"
               role="img"
-              aria-label="Defined natural curls after hydration treatment"
-              style="--client-image: url('assets/images/clients/natural-curl-revive.png')"
+              aria-label="Client portrait showcasing defined natural curls"
+              style="--client-image: url('/assets/images/clients/img-4.jpg')"
             ></div>
-            <figcaption>Hydrating curl revival that boosts definition and bounce.</figcaption>
+            <figcaption>Defined curls shaped for balanced volume and movement.</figcaption>
+          </figure>
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Client portrait revealing a fresh fringe and soft layering"
+              style="--client-image: url('/assets/images/clients/img-3.jpg')"
+            ></div>
+            <figcaption>Soft layering with a modern fringe tailored to frame the face.</figcaption>
+          </figure>
+          <figure class="client-card" role="listitem">
+            <div
+              class="client-photo"
+              role="img"
+              aria-label="Client portrait capturing a formal upstyle with shine"
+              style="--client-image: url('/assets/images/clients/img-2.jpg')"
+            ></div>
+            <figcaption>Event-ready styling featuring a polished, luminous updo.</figcaption>
           </figure>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- showcase the newly provided client photography throughout the hero and gallery sections
- expand the client gallery with six polished examples and refreshed descriptive copy for each style
- ensure background image references use root-relative paths so the assets load correctly

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e9602e97a4832cbf0682fedcd0e2af