### PR TITLE
Adjust site background to gunmetal grey

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --bg-color: #0f0f10;
-  --bg-alt-color: #1c1c1f;
+  --bg-color: #2b343b;
+  --bg-alt-color: #1f262a;
   --accent-color: #d6a354;
   --text-color: #f1f1f5;
   --text-muted: #b5b5be;
@@ -16,7 +16,7 @@
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
-  background: radial-gradient(circle at top, rgba(214, 163, 84, 0.15), transparent 60%), var(--bg-color);
+  background: radial-gradient(circle at top, rgba(74, 86, 92, 0.2), transparent 60%), var(--bg-color);
   color: var(--text-color);
   line-height: 1.6;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- update the global background color variables to use a gunmetal grey palette
- soften the radial gradient overlay to complement the new neutral background tone

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e9621a6dd4832cac302c696c296b27