### PR TITLE
Add social links and client gallery lightbox

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -34,10 +34,13 @@ a:hover {
 header {
   position: sticky;
   top: 0;
+  left: 0;
+  width: 100%;
   background: rgba(15, 15, 16, 0.95);
   backdrop-filter: blur(10px);
   z-index: 100;
   border-bottom: 1px solid rgba(214, 163, 84, 0.15);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
 }
 
 .navbar {
@@ -285,6 +288,7 @@ section {
 }
 
 .client-photo {
+  display: block;
   width: 100%;
   aspect-ratio: 3 / 4;
   background-color: rgba(17, 17, 20, 0.95);
@@ -298,6 +302,14 @@ section {
   background-repeat: no-repeat, no-repeat;
   border-bottom: 1px solid rgba(214, 163, 84, 0.18);
   filter: saturate(1.05) contrast(1.05);
+  border: none;
+  cursor: zoom-in;
+  padding: 0;
+}
+
+.client-photo:focus-visible {
+  outline: 3px solid rgba(214, 163, 84, 0.8);
+  outline-offset: 4px;
 }
 
 .client-card figcaption {
@@ -418,6 +430,59 @@ section {
   width: 100%;
 }
 
+.social-buttons {
+  margin: 3rem auto 0;
+  max-width: var(--max-width);
+  text-align: center;
+}
+
+.social-buttons p {
+  margin: 0.75rem auto 2rem;
+  max-width: 28rem;
+  color: var(--text-muted);
+}
+
+.social-buttons-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.social-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 10rem;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 163, 84, 0.25);
+  background: rgba(214, 163, 84, 0.12);
+  color: var(--text-color);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.social-button:hover,
+.social-button:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(214, 163, 84, 0.25);
+  border-color: var(--accent-color);
+}
+
+.social-button.instagram {
+  box-shadow: 0 10px 25px rgba(193, 53, 132, 0.2);
+}
+
+.social-button.facebook {
+  box-shadow: 0 10px 25px rgba(59, 89, 152, 0.18);
+}
+
+.social-button.maps {
+  box-shadow: 0 10px 25px rgba(72, 133, 237, 0.18);
+}
+
 .directions {
   max-width: var(--max-width);
   margin: 0 auto;
@@ -459,6 +524,97 @@ section {
   margin-bottom: 0.5rem;
 }
 
+body.lightbox-open {
+  overflow: hidden;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 12, 0.85);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  transition: opacity var(--transition), visibility var(--transition);
+  opacity: 1;
+  visibility: visible;
+  z-index: 999;
+}
+
+.lightbox[aria-hidden='true'] {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.lightbox-content {
+  position: relative;
+  background: rgba(20, 20, 23, 0.95);
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(214, 163, 84, 0.25);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  max-width: min(90vw, 700px);
+  width: 100%;
+}
+
+.lightbox-image-wrapper {
+  overflow: hidden;
+  border-radius: 1rem;
+  background: #111114;
+}
+
+.lightbox-image-wrapper img {
+  display: block;
+  width: 100%;
+  height: auto;
+  transform-origin: center;
+  transition: transform 0.2s ease;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.lightbox-close:hover,
+.lightbox-close:focus-visible {
+  color: var(--accent-color);
+}
+
+.lightbox-controls {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.lightbox-zoom {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 1px solid rgba(214, 163, 84, 0.4);
+  background: rgba(214, 163, 84, 0.15);
+  color: var(--text-color);
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+.lightbox-zoom:hover,
+.lightbox-zoom:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(214, 163, 84, 0.3);
+  border-color: var(--accent-color);
+}
+
 footer {
   border-top: 1px solid rgba(214, 163, 84, 0.15);
   padding: 2rem 1.5rem;
@@ -493,7 +649,7 @@ footer a {
 }
 
 @media (max-width: 540px) {
-  .client-card img {
+  .client-photo {
     height: 200px;
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,3 +15,91 @@ document.querySelectorAll('.nav-links a').forEach((link) => {
     }
   });
 });
+
+const clientPhotos = document.querySelectorAll('.client-photo');
+const lightbox = document.querySelector('.lightbox');
+const lightboxImage = lightbox?.querySelector('img');
+const lightboxClose = document.querySelector('.lightbox-close');
+const zoomInButton = document.querySelector('.lightbox-zoom-in');
+const zoomOutButton = document.querySelector('.lightbox-zoom-out');
+
+let currentScale = 1;
+let lastFocusedPhoto = null;
+
+const setScale = (scale) => {
+  currentScale = Number(Math.min(2.75, Math.max(1, scale)).toFixed(2));
+  if (lightboxImage) {
+    lightboxImage.style.transform = `scale(${currentScale})`;
+  }
+};
+
+const closeLightbox = () => {
+  if (!lightbox || !lightboxImage) return;
+  lightbox.setAttribute('aria-hidden', 'true');
+  lightboxImage.src = '';
+  lightboxImage.alt = '';
+  document.body.classList.remove('lightbox-open');
+  setScale(1);
+  if (lastFocusedPhoto) {
+    lastFocusedPhoto.focus();
+    lastFocusedPhoto = null;
+  }
+};
+
+const openLightbox = (src, alt, trigger) => {
+  if (!lightbox || !lightboxImage) return;
+  lightboxImage.src = src;
+  lightboxImage.alt = alt || 'Client hairstyle result';
+  lightbox.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('lightbox-open');
+  setScale(1);
+  lastFocusedPhoto = trigger ?? null;
+  lightboxClose?.focus();
+};
+
+const zoomIn = () => setScale(currentScale + 0.25);
+const zoomOut = () => setScale(currentScale - 0.25);
+
+clientPhotos.forEach((photo) => {
+  photo.addEventListener('click', () => {
+    const src = photo.dataset.image;
+    if (!src) return;
+    const altText =
+      photo.dataset.alt ||
+      photo.getAttribute('aria-label') ||
+      photo.closest('figure')?.querySelector('figcaption')?.textContent?.trim() ||
+      'Client hairstyle result';
+    openLightbox(src, altText, photo);
+  });
+});
+
+lightboxClose?.addEventListener('click', closeLightbox);
+
+lightbox?.addEventListener('click', (event) => {
+  if (event.target === lightbox) {
+    closeLightbox();
+  }
+});
+
+zoomInButton?.addEventListener('click', zoomIn);
+zoomOutButton?.addEventListener('click', zoomOut);
+
+document.addEventListener('keydown', (event) => {
+  if (!lightbox || lightbox.getAttribute('aria-hidden') === 'true') {
+    return;
+  }
+
+  if (event.key === 'Escape') {
+    closeLightbox();
+  }
+
+  if (event.key === '+' || event.key === '=') {
+    event.preventDefault();
+    zoomIn();
+  }
+
+  if (event.key === '-' || event.key === '_') {
+    event.preventDefault();
+    zoomOut();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -114,57 +114,69 @@
         </div>
         <div class="client-gallery-grid" role="list">
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait showing soft waves with subtle highlights"
+              data-image="/assets/images/clients/img-10.jpg"
+              data-alt="Client portrait showing soft waves with subtle highlights"
               style="--client-image: url('/assets/images/clients/img-10.jpg')"
-            ></div>
+            ></button>
             <figcaption>Polished finish with touchable waves and dimensional shine.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait featuring a sleek, shoulder-length cut"
+              data-image="/assets/images/clients/img-8.jpg"
+              data-alt="Client portrait featuring a sleek, shoulder-length cut"
               style="--client-image: url('/assets/images/clients/img-8.jpg')"
-            ></div>
+            ></button>
             <figcaption>Sleek silhouette paired with a smooth, reflective finish.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait highlighting a rich brunette color service"
+              data-image="/assets/images/clients/img-6.jpg"
+              data-alt="Client portrait highlighting a rich brunette color service"
               style="--client-image: url('/assets/images/clients/img-6.jpg')"
-            ></div>
+            ></button>
             <figcaption>Rich color depth enhanced with healthy, light-catching gloss.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait showcasing defined natural curls"
+              data-image="/assets/images/clients/img-4.jpg"
+              data-alt="Client portrait showcasing defined natural curls"
               style="--client-image: url('/assets/images/clients/img-4.jpg')"
-            ></div>
+            ></button>
             <figcaption>Defined curls shaped for balanced volume and movement.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait revealing a fresh fringe and soft layering"
+              data-image="/assets/images/clients/img-3.jpg"
+              data-alt="Client portrait revealing a fresh fringe and soft layering"
               style="--client-image: url('/assets/images/clients/img-3.jpg')"
-            ></div>
+            ></button>
             <figcaption>Soft layering with a modern fringe tailored to frame the face.</figcaption>
           </figure>
           <figure class="client-card" role="listitem">
-            <div
+            <button
               class="client-photo"
-              role="img"
+              type="button"
               aria-label="Client portrait capturing a formal upstyle with shine"
+              data-image="/assets/images/clients/img-2.jpg"
+              data-alt="Client portrait capturing a formal upstyle with shine"
               style="--client-image: url('/assets/images/clients/img-2.jpg')"
-            ></div>
+            ></button>
             <figcaption>Event-ready styling featuring a polished, luminous updo.</figcaption>
           </figure>
         </div>
@@ -248,6 +260,39 @@
             <button class="btn btn-primary" type="submit">Send Message</button>
           </form>
         </div>
+        <div class="social-buttons" aria-labelledby="connect-title">
+          <h3 id="connect-title">Connect with HairU</h3>
+          <p>Stay inspired and plan your visit through our favorite platforms.</p>
+          <div class="social-buttons-group">
+            <a
+              class="social-button instagram"
+              href="https://www.instagram.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Follow HairU Salon on Instagram"
+            >
+              Instagram
+            </a>
+            <a
+              class="social-button facebook"
+              href="https://www.facebook.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Connect with HairU Salon on Facebook"
+            >
+              Facebook
+            </a>
+            <a
+              class="social-button maps"
+              href="https://maps.google.com/?q=HairU+Salon+Seattle"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open HairU Salon on Google Maps"
+            >
+              Google Maps
+            </a>
+          </div>
+        </div>
       </section>
 
       <section id="directions" aria-labelledby="directions-title">
@@ -301,9 +346,22 @@
       </p>
       <p>
         Built with accessible, responsive design ready for GitHub Pages hosting. Follow us on
-        <a href="#">Instagram</a> for fresh inspiration.
+        <a href="https://www.instagram.com/" target="_blank" rel="noopener noreferrer">Instagram</a> for fresh inspiration.
       </p>
     </footer>
+
+    <div class="lightbox" role="dialog" aria-modal="true" aria-hidden="true">
+      <div class="lightbox-content">
+        <button class="lightbox-close" type="button" aria-label="Close image preview">&times;</button>
+        <div class="lightbox-image-wrapper">
+          <img src="" alt="" />
+        </div>
+        <div class="lightbox-controls" aria-label="Image zoom controls">
+          <button class="lightbox-zoom lightbox-zoom-out" type="button" aria-label="Zoom out">&minus;</button>
+          <button class="lightbox-zoom lightbox-zoom-in" type="button" aria-label="Zoom in">+</button>
+        </div>
+      </div>
+    </div>
 
     <script src="assets/js/main.js" defer></script>
     <script>


### PR DESCRIPTION
## Summary
- convert client gallery tiles into interactive buttons that open a zoomable lightbox
- add social media buttons and update the sticky header styling for better scrolling behavior
- include new overlay styling and scripts to support image zoom controls

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e976be44f8832c88473970caf0b226