### PR TITLE
Toggle lightbox image zoom on click

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -570,6 +570,11 @@ body.lightbox-open {
   height: auto;
   transform-origin: center;
   transition: transform 0.2s ease;
+  cursor: zoom-in;
+}
+
+.lightbox-image-wrapper img.is-zoomed {
+  cursor: zoom-out;
 }
 
 .lightbox-close {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -30,6 +30,7 @@ const setScale = (scale) => {
   currentScale = Number(Math.min(2.75, Math.max(1, scale)).toFixed(2));
   if (lightboxImage) {
     lightboxImage.style.transform = `scale(${currentScale})`;
+    lightboxImage.classList.toggle('is-zoomed', currentScale > 1);
   }
 };
 
@@ -59,6 +60,7 @@ const openLightbox = (src, alt, trigger) => {
 
 const zoomIn = () => setScale(currentScale + 0.25);
 const zoomOut = () => setScale(currentScale - 0.25);
+const toggleZoom = () => setScale(currentScale > 1 ? 1 : 2);
 
 clientPhotos.forEach((photo) => {
   photo.addEventListener('click', () => {
@@ -83,6 +85,7 @@ lightbox?.addEventListener('click', (event) => {
 
 zoomInButton?.addEventListener('click', zoomIn);
 zoomOutButton?.addEventListener('click', zoomOut);
+lightboxImage?.addEventListener('click', toggleZoom);
 
 document.addEventListener('keydown', (event) => {
   if (!lightbox || lightbox.getAttribute('aria-hidden') === 'true') {


### PR DESCRIPTION
## Summary
- toggle the lightbox image between zoomed and original scale when it is clicked
- update zoom state handling to sync cursor feedback with the current scale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e979a0db3c832ca4fe75363adcf907